### PR TITLE
Change SWIG interfaces and config to be compatible with x11 backend

### DIFF
--- a/config.py
+++ b/config.py
@@ -1109,6 +1109,8 @@ elif os.name == 'posix' or COMPILER == 'mingw32':
             portcfg = os.popen('pkg-config gtk+-3.0 --cflags', 'r').read()[:-1]
         elif WXPORT == 'x11':
             WXPLAT = '__WXX11__'
+            WXPLAT2 = '__WXUNIVERSAL__'
+            BUILD_GLCANVAS = 0 # Cannot build GLCanvas with x11 backend
             portcfg = ''
             BUILD_BASE = BUILD_BASE + '-' + WXPORT
         elif WXPORT == 'msw':

--- a/src/_bitmap.i
+++ b/src/_bitmap.i
@@ -89,6 +89,7 @@ enum wxBitmapBufferFormat {
 };
 
 
+#ifndef __WXUNIVERSAL__
     void wxPyCopyBitmapFromBuffer(wxBitmap* bmp,
                                   buffer data, int DATASIZE,
                                   wxBitmapBufferFormat format, int stride=-1)
@@ -393,6 +394,7 @@ enum wxBitmapBufferFormat {
             }
         }
     }
+#endif
     
 %}
 
@@ -669,6 +671,7 @@ the ``type`` parameter.", "");
 #endif
 
     
+#ifndef __WXUNIVERSAL__
     %extend {
         DocStr(CopyFromBuffer,
                "Copy data from a buffer object to replace the bitmap pixel data.
@@ -716,11 +719,14 @@ format details.", "");
             wxPyCopyBitmapToBuffer(self, data, DATASIZE, format, stride);
         }
     }
+#endif
 
     
     // (these functions are internal and shouldn't be used, they risk to
     // disappear in the future)
+#ifndef __WXUNIVERSAL__
     bool HasAlpha() const;
+#endif
     
     %pythoncode { def __nonzero__(self): return self.IsOk() }
 
@@ -747,6 +753,7 @@ format details.", "");
 // the wxBitmap's pixel buffer.
 
 
+#ifndef __WXUNIVERSAL__
 %newobject _BitmapFromBufferAlpha;
 %newobject _BitmapFromBuffer;
 %inline %{
@@ -1125,6 +1132,7 @@ PIXELDATA(wxAlphaPixelData)
         return rv;            
     }
 }
+#endif
 
 
 //---------------------------------------------------------------------------

--- a/src/_choice.i
+++ b/src/_choice.i
@@ -74,6 +74,7 @@ public:
     String name=ChoiceNameStr) -> bool",
         "Actually create the GUI Choice control for 2-phase creation", "");
 
+#ifndef __WXUNIVERSAL__
     DocDeclStr(
         int , GetCurrentSelection() const,
         "Unlike `GetSelection` which only returns the accepted selection value,
@@ -82,13 +83,16 @@ list, this function returns the current selection.  That is, while the
 dropdown list is shown, it returns the currently selected item in
 it. When it is not shown, its result is the same as for the other
 function.", "");
+#endif
     
 
     static wxVisualAttributes
     GetClassDefaultAttributes(wxWindowVariant variant = wxWINDOW_VARIANT_NORMAL);
 
 
+#ifndef __WXUNIVERSAL__
     %property(CurrentSelection, GetCurrentSelection, doc="See `GetCurrentSelection`");
+#endif
     
 };
 

--- a/src/_combobox.i
+++ b/src/_combobox.i
@@ -144,6 +144,7 @@ the combobox text field.", "",
     virtual void Dismiss();
 
 
+#ifndef __WXUNIVERSAL__
     DocDeclStr(
         int , GetCurrentSelection() const,
         "Unlike `GetSelection` which only returns the accepted selection value,
@@ -152,6 +153,7 @@ list, this function returns the current selection.  That is, while the
 dropdown list is shown, it returns the currently selected item in
 it. When it is not shown, its result is the same as for the other
 function.", "");
+#endif
     
     DocDeclStr(
         bool , SetStringSelection(const wxString& string),
@@ -167,7 +169,9 @@ function.", "");
     static wxVisualAttributes
     GetClassDefaultAttributes(wxWindowVariant variant = wxWINDOW_VARIANT_NORMAL);
 
+#ifndef __WXUNIVERSAL__
     %property(CurrentSelection, GetCurrentSelection);
+#endif
     %property(Mark, GetMark, SetMark);
 
 };

--- a/src/_dataobj.i
+++ b/src/_dataobj.i
@@ -104,10 +104,12 @@ name.", "",
     bool operator!=(const wxDataFormat& format) const;
 
     
+#ifndef __WXUNIVERSAL__
     DocDeclStr(
         void , SetType(wxDataFormatId format),
         "Sets the format to the given value, which should be one of wx.DF_XXX
 constants.", "");
+#endif
     
     DocDeclStr(
         wxDataFormatId , GetType() const,
@@ -128,7 +130,9 @@ standard format)."""
         "Sets the format to be the custom format identified by the given name.", "");    
 
     %property(Id, GetId, SetId, doc="See `GetId` and `SetId`");
+#ifndef __WXUNIVERSAL__
     %property(Type, GetType, SetType, doc="See `GetType` and `SetType`");
+#endif
 };
 
 

--- a/src/_font.i
+++ b/src/_font.i
@@ -258,7 +258,9 @@ public:
     wxFontStyle GetStyle() const;
     wxFontWeight GetWeight() const;
     bool GetUnderlined() const;
+#ifndef __WXUNIVERSAL__
     bool GetStrikethrough() const;
+#endif
     wxString GetFaceName() const;
     wxFontFamily GetFamily() const;
     wxFontEncoding GetEncoding() const;

--- a/src/_functions.i
+++ b/src/_functions.i
@@ -116,7 +116,7 @@ bool wxIsPlatform64Bit();
     %#endif
 }
 
-#if defined(__WXMSW__) || defined(__WXMAC__)
+#if defined(__WXMSW__) || defined(__WXMAC__) || defined(__WXUNIVERSAL__)
 wxMemorySize wxGetFreeMemory();
 #else
 %inline %{

--- a/src/_graphics.i
+++ b/src/_graphics.i
@@ -308,11 +308,13 @@ public:
         return NULL;
     }
 
+#ifndef __WXUNIVERSAL__
     static wxGraphicsContext* Create( const wxEnhMetaFileDC& )  {
         PyErr_SetString(PyExc_NotImplementedError,
                         "wx.GraphicsContext is not available on this platform.");
         return NULL;
     }
+#endif
 
     static wxGraphicsContext* Create( const wxWindowDC& )  {
         PyErr_SetString(PyExc_NotImplementedError,
@@ -490,7 +492,9 @@ public :
         return NULL;
     }   
 
+#ifndef __WXUNIVERSAL__
     virtual wxGraphicsContext * CreateContext( const wxEnhMetaFileDC& ) { return NULL; }
+#endif
     virtual wxGraphicsContext * CreateContext( const wxWindowDC& ) { return NULL; }
     virtual wxGraphicsContext * CreateContext( const wxMemoryDC& ) { return NULL; }
     virtual wxGraphicsContext * CreateContext( const wxPrinterDC& ) { return NULL; }

--- a/src/_radio.i
+++ b/src/_radio.i
@@ -80,11 +80,13 @@ public:
     // return the item above/below/to the left/right of the given one
     int GetNextItem(int item, wxDirection dir, long style) const;
 
+#ifndef __WXUNIVERSAL__
     // set the tooltip text for a radio item, empty string unsets any tooltip
     void SetItemToolTip(unsigned int item, const wxString& text);
 
     // get the individual items tooltip; returns NULL if none
     wxToolTip *GetItemToolTip(unsigned int item) const;
+#endif
 
     // set helptext for a particular item, pass an empty string to erase it
     void SetItemHelpText(unsigned int n, const wxString& helpText);

--- a/src/_renderer.i
+++ b/src/_renderer.i
@@ -332,7 +332,7 @@ button only) because there is no way to render standard title bar
 buttons under the other platforms, the best can be done is to use
 normal (only) images which wxArtProvider provides for wxART_HELP and
 wxART_CLOSE (but not any other title bar buttons)", "");
-#ifdef __WXGTK__
+#if defined(__WXGTK__) || defined(__WXUNIVERSAL__)
     %extend {
         void DrawTitleBarBitmap(wxWindow *win,
                                 wxDC& dc,

--- a/src/_richtextctrl.i
+++ b/src/_richtextctrl.i
@@ -201,6 +201,7 @@ during sizing.", "");
     bool GetDragging() const;
     void SetDragging(bool dragging);
 
+#ifndef __WXUNIVERSAL__
     /**
         Are we trying to start Drag'n'Drop?
     */
@@ -230,6 +231,7 @@ during sizing.", "");
         Set the possible Drag'n'Drop start time
     */
     void SetDragStartTime(wxDateTime st) { m_dragStartTime = st; }
+#endif
 
 
     

--- a/src/_taskbar.i
+++ b/src/_taskbar.i
@@ -38,8 +38,10 @@ enum wxTaskBarIconType
 class wxTaskBarIcon : public wxEvtHandler
 {
 public:
+#ifndef __WXUNIVERSAL__
     wxTaskBarIcon(wxTaskBarIconType iconType=wxTBI_DEFAULT_TYPE)
     { wxPyRaiseNotImplemented(); }
+#endif
 };
 
 
@@ -80,8 +82,10 @@ class wxPyTaskBarIcon : public wxTaskBarIcon
 {
     DECLARE_ABSTRACT_CLASS(wxPyTaskBarIcon)
 public:
+#ifndef __WXUNIVERSAL__
     wxPyTaskBarIcon(wxTaskBarIconType iconType=wxTBI_DEFAULT_TYPE) :
         wxTaskBarIcon(iconType) {}
+#endif
     
     wxMenu* CreatePopupMenu() {
         wxMenu *rval = NULL;
@@ -128,7 +132,9 @@ class wxPyTaskBarIcon : public wxEvtHandler
 public:
     %pythonAppend wxPyTaskBarIcon   "self._setOORInfo(self);" setCallbackInfo(TaskBarIcon)
 
+#ifndef __WXUNIVERSAL__
     wxPyTaskBarIcon(wxTaskBarIconType iconType=wxTBI_DEFAULT_TYPE);
+#endif
     ~wxPyTaskBarIcon();
 
     void _setCallbackInfo(PyObject* self, PyObject* _class, int incref=0);

--- a/src/_window.i
+++ b/src/_window.i
@@ -2362,7 +2362,9 @@ opaque.", "");
     %property(ContainingSizer, GetContainingSizer, SetContainingSizer, doc="See `GetContainingSizer` and `SetContainingSizer`");
     %property(Cursor, GetCursor, SetCursor, doc="See `GetCursor` and `SetCursor`");
     %property(DefaultAttributes, GetDefaultAttributes, doc="See `GetDefaultAttributes`");
+#ifndef __WXUNIVERSAL__
     %property(DropTarget, GetDropTarget, SetDropTarget, doc="See `GetDropTarget` and `SetDropTarget`");
+#endif
     %property(EventHandler, GetEventHandler, SetEventHandler, doc="See `GetEventHandler` and `SetEventHandler`");
     %property(ExtraStyle, GetExtraStyle, SetExtraStyle, doc="See `GetExtraStyle` and `SetExtraStyle`");
     %property(Font, GetFont, SetFont, doc="See `GetFont` and `SetFont`");
@@ -2389,7 +2391,9 @@ opaque.", "");
     %property(Size, GetSize, SetSize, doc="See `GetSize` and `SetSize`");
     %property(Sizer, GetSizer, SetSizer, doc="See `GetSizer` and `SetSizer`");
     %property(ThemeEnabled, GetThemeEnabled, SetThemeEnabled, doc="See `GetThemeEnabled` and `SetThemeEnabled`");
+#ifndef __WXUNIVERSAL__
     %property(ToolTip, GetToolTip, SetToolTip, doc="See `GetToolTip` and `SetToolTip`");
+#endif
     %property(UpdateClientRect, GetUpdateClientRect, doc="See `GetUpdateClientRect`");
     %property(UpdateRegion, GetUpdateRegion, doc="See `GetUpdateRegion`");
     %property(Validator, GetValidator, SetValidator, doc="See `GetValidator` and `SetValidator`");

--- a/src/dataview.i
+++ b/src/dataview.i
@@ -2488,8 +2488,10 @@ public:
     virtual void EditItem(const wxDataViewItem& item, const wxDataViewColumn *column);
 //    virtual void StartEditor( const wxDataViewItem & item, unsigned int column );
     
+#ifndef __WXUNIVERSAL__
     virtual bool EnableDragSource(const wxDataFormat& format);
     virtual bool EnableDropTarget(const wxDataFormat& format);
+#endif
 
     %property(Model, GetModel, AssociateModel);
     %property(ColumnCount, GetColumnCount);
@@ -2541,9 +2543,12 @@ public:
     
     // For drag operations
     %disownarg( wxDataObject *obj );
+#ifndef __WXUNIVERSAL__
     void SetDataObject( wxDataObject *obj );
+#endif
     %cleardisown( wxDataObject *obj );
 
+#ifndef __WXUNIVERSAL__
     wxDataObject *GetDataObject() const;
 
     // For drop operations
@@ -2559,6 +2564,7 @@ public:
 
     void SetDragFlags(int flags);
     int GetDragFlags() const;
+#endif
 
     
     %property(Column, GetColumn, SetColumn);


### PR DESCRIPTION
This revision makes it possible to build with the x11 backend by removing some optional features that aren't compatible with it.

This change always requires a change to include/wx/stc/stc.h in wxWidgets:

```
 // SWIG can't handle "#if" type of conditionals, only "#ifdef"
 #ifdef SWIG
+#ifndef __WXUNIVERSAL__
 #define STC_USE_DND 1
+#endif
 #else
 #if wxUSE_DRAG_AND_DROP
 #define STC_USE_DND 1
```

This disables drag and drop in the stc_wrap.cpp file.

I also disabled glcanvas for this build, which didn't build successfully. I didn't explore options for making it build much, it's possible that it could build given some other changes.
