### PR TITLE
to solve: dummy node is removed by error

### DIFF
--- a/wx/tools/XRCed/listener.py
+++ b/wx/tools/XRCed/listener.py
@@ -137,7 +137,7 @@ class _Listener:
         wx.EVT_MENU_HIGHLIGHT_ALL(self.frame, self.OnMenuHighlight)
 
         # XMLTree events
-        tree.Bind(wx.EVT_LEFT_DOWN, self.OnTreeLeftDown)
+        # tree.Bind(wx.EVT_LEFT_DOWN, self.OnTreeLeftDown)
         tree.Bind(wx.EVT_RIGHT_DOWN, self.OnTreeRightDown)
         tree.Bind(wx.EVT_TREE_SEL_CHANGING, self.OnTreeSelChanging)
         tree.Bind(wx.EVT_TREE_SEL_CHANGED, self.OnTreeSelChanged)


### PR DESCRIPTION
to solve the following issue:
1.in CRCED, new a frame
2.click the blank in left tree panel to select nothing
3.click the wxFrame in left tree
4.save it as f.xrc, then f.xrc gets error.

if you accept my push, the two issues will be solved too.
1.if the wxFrame is named, when i unselect it, the name in the left tree is missed.
2.when you try to save it, the resource tag in the xml has a name.
I find that my way is the easiest way to solve all the questions.
